### PR TITLE
Make LogsAPIConnTTL configurable

### DIFF
--- a/src/adapter/app/adapter.go
+++ b/src/adapter/app/adapter.go
@@ -154,6 +154,7 @@ func NewAdapter(
 	metricClient MetricClient,
 	logClient LogClient,
 	sourceIndex string,
+	LogsAPIConnTTL time.Duration,
 	opts ...AdapterOption,
 ) *Adapter {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -165,7 +166,7 @@ func NewAdapter(
 		ctx:                    ctx,
 		cancel:                 cancel,
 		logsAPIConnCount:       10,
-		logsAPIConnTTL:         600 * time.Second,
+		logsAPIConnTTL:         LogsAPIConnTTL,
 		logsEgressAPITLSConfig: logsEgressAPITLSConfig,
 		adapterServerTLSConfig: adapterServerTLSConfig,
 		syslogDialTimeout:      5 * time.Second,

--- a/src/adapter/app/config.go
+++ b/src/adapter/app/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	MetricIngressAddr     string        `env:"METRIC_INGRESS_ADDR,     required"`
 	MetricIngressCN       string        `env:"METRIC_INGRESS_CN,       required"`
 	MetricEmitterInterval time.Duration `env:"METRIC_EMITTER_INTERVAL"`
+	LogsAPIConnTTL        time.Duration `env:"LOGS_API_CONN_TTL"`
 }
 
 // LoadConfig will load and validate the config from the current environment.
@@ -51,6 +52,7 @@ func LoadConfig() *Config {
 		MetricEmitterInterval:  time.Minute,
 		MetricsToSyslogEnabled: false,
 		MaxBindings:            500,
+		LogsAPIConnTTL:         600 * time.Second,
 	}
 
 	err := envstruct.Load(&cfg)

--- a/src/adapter/main.go
+++ b/src/adapter/main.go
@@ -76,6 +76,7 @@ func main() {
 		metricClient,
 		logClient,
 		cfg.SourceIndex,
+		cfg.LogsAPIConnTTL,
 		app.WithHealthAddr(cfg.HealthHostport),
 		app.WithAdapterServerAddr(cfg.AdapterHostport),
 		app.WithSyslogKeepalive(cfg.SyslogKeepalive),


### PR DESCRIPTION
To be able to change TTL which used for rebalance connections to RLP

Next patch is going to be spec file patch for release's job if this one is okay

reference: https://github.com/cloudfoundry/cf-syslog-drain-release/issues/21