### PR TITLE
Add logs_api_conn_ttl option

### DIFF
--- a/jobs/adapter/spec
+++ b/jobs/adapter/spec
@@ -71,6 +71,12 @@ properties:
     description: |
         The maximum number of bindings that can be serviced by an adapter.
     default: 500
+  scalablesyslog.adapter.logs_api_conn_ttl:
+    description: |
+        The TTL of connection to Logs API(s).
+        Each logs_api_conn_ttl interval adapter reconnects to Logs API(s) in sake of rebalancing.
+        WARNING: during the reconnection log lost is possible.
+    default: 600s
 
   scalablesyslog.adapter.tls.ca:
     description: |

--- a/jobs/adapter/templates/bpm.yml.erb
+++ b/jobs/adapter/templates/bpm.yml.erb
@@ -40,5 +40,6 @@ processes:
       METRIC_INGRESS_ADDR: "<%= p('scalablesyslog.metric_ingress_addr') %>"
       METRIC_INGRESS_CN: "<%= p('scalablesyslog.metric_ingress_cn') %>"
       METRIC_EMITTER_INTERVAL: "<%= p('metric_emitter.interval') %>"
+      LOGS_API_CONN_TTL: "<%= p('scalablesyslog.adapter.logs_api_conn_ttl') %>"
     limits:
       open_files: 8192


### PR DESCRIPTION
scalablesyslog.adapter.logs_api_conn_ttl allows to configure TTL of connection to Logs API

https://github.com/cloudfoundry/cf-syslog-drain-release/issues/21