### PR TITLE
Update indicators.yml.erb

### DIFF
--- a/jobs/adapter/templates/indicators.yml.erb
+++ b/jobs/adapter/templates/indicators.yml.erb
@@ -5,6 +5,7 @@ kind: IndicatorDocument
 metadata:
   labels:
     deployment: <%= spec.deployment %>
+    component: adapter
 
 spec:
   product:


### PR DESCRIPTION
Adds a `component` key to metadata to ensure that documents for different jobs don't overwrite each other.